### PR TITLE
fix: Prevent duplicate issues from `jq` errors in the “normalize_cache” step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         # If cached data is a list of Finding objects, each with 'issueUrl' keys (i.e. v1),
         # convert to a list of (partial) Result objects, each with 'findings' and 'issue' keys (i.e. v2).
         # Otherwise, re-output as-is.
-        echo "value=$(echo '${{ steps.restore.outputs.value }}' | jq 'if (type == "array" and length > 0 and .[0] | has("issueUrl")) then map({findings: [del(.issueUrl)], issue: {url: .issueUrl}}) else . end' )" >> $GITHUB_OUTPUT
+        echo "value=$(printf '%s' '${{ steps.restore.outputs.value }}' | jq 'if (type == "array" and length > 0 and (.[0] | has("issueUrl"))) then map({findings: [del(.issueUrl)], issue: {url: .issueUrl}}) else . end' )" >> $GITHUB_OUTPUT
     - if: ${{ inputs.login_url && inputs.username && inputs.password && !inputs.auth_context }}
       name: Authenticate
       id: auth


### PR DESCRIPTION
This PR prevents duplicate issues from being opened after repeated workflow runs by fixing two `jq` errors in the “normalize_cache” step:

- `jq: error (at <stdin>:1): Cannot check whether boolean has a string key` was fixed by wrapping `(.[0] | has("issueUrl"))` so `has()` runs only after confirming a non-empty array, avoiding `has()` on a boolean.
- `jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped` was fixed by using `printf '%s'` instead of `echo` to preserve literal escape sequences (`\n`, etc.).