### PR TITLE
fix: Output compact (one-line) JSON

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         # If cached data is a list of Finding objects, each with 'issueUrl' keys (i.e. v1),
         # convert to a list of (partial) Result objects, each with 'findings' and 'issue' keys (i.e. v2).
         # Otherwise, re-output as-is.
-        echo "value=$(printf '%s' '${{ steps.restore.outputs.value }}' | jq 'if (type == "array" and length > 0 and (.[0] | has("issueUrl"))) then map({findings: [del(.issueUrl)], issue: {url: .issueUrl}}) else . end' )" >> $GITHUB_OUTPUT
+        printf '%s' "value=$(printf '%s' '${{ steps.restore.outputs.value }}' | jq -c 'if (type == "array" and length > 0 and (.[0] | has("issueUrl"))) then map({findings: [del(.issueUrl)], issue: {url: .issueUrl}}) else . end' )" >> $GITHUB_OUTPUT
     - if: ${{ inputs.login_url && inputs.username && inputs.password && !inputs.auth_context }}
       name: Authenticate
       id: auth


### PR DESCRIPTION
Follow-up to #10 

This PR updates the “normalize_cache” step to output compact (one-line) JSON, since a GitHub Actions output cannot span multiple lines.