### PR TITLE
fix(File): Read the `cached_filings` input, not `cached_results`

### DIFF
--- a/.github/actions/file/src/index.ts
+++ b/.github/actions/file/src/index.ts
@@ -21,7 +21,7 @@ export default async function () {
   const repoWithOwner = core.getInput("repository", { required: true });
   const token = core.getInput("token", { required: true });
   const cachedFilings: (ResolvedFiling | RepeatedFiling)[] = JSON.parse(
-    core.getInput("cached_results", { required: false }) || "[]"
+    core.getInput("cached_filings", { required: false }) || "[]"
   );
   core.debug(`Input: 'findings: ${JSON.stringify(findings)}'`);
   core.debug(`Input: 'repository: ${repoWithOwner}'`);


### PR DESCRIPTION
This PR updates the `core.getInput` call to match the `action.yml` (https://github.com/github/accessibility-scanner/blob/69cb82cdc3d9e37c418092e71af165108b31911c/.github/actions/file/action.yml#L14-L16), so results from previous runs are now available to the File sub-action. This ensures duplicate issues aren’t filed when the workflow re-runs.