### PR TITLE
fix(Find): Replace single quotes in Finding’s `html` field

### DIFF
--- a/.github/actions/find/src/findForUrl.ts
+++ b/.github/actions/find/src/findForUrl.ts
@@ -16,12 +16,12 @@ export async function findForUrl(url: string, authContext?: AuthContext): Promis
     findings = rawFindings.violations.map(violation => ({
       scannerType: 'axe',
       url,
-      html: violation.nodes[0].html,
-      problemShort: violation.help.toLowerCase().replace(/[']/g, '’'),
-      problemUrl: violation.helpUrl.replace(/[']/g, '’'),
+      html: violation.nodes[0].html.replace(/'/g, "&apos;"),
+      problemShort: violation.help.toLowerCase().replace(/'/g, "&apos;"),
+      problemUrl: violation.helpUrl.replace(/'/g, "&apos;"),
       ruleId: violation.id,
-      solutionShort: violation.description.toLowerCase().replace(/[']/g, '’'),
-      solutionLong: violation.nodes[0].failureSummary?.replace(/[']/g, '’')
+      solutionShort: violation.description.toLowerCase().replace(/'/g, "&apos;"),
+      solutionLong: violation.nodes[0].failureSummary?.replace(/'/g, "&apos;")
     }));
   } catch (e) {
     // do something with the error


### PR DESCRIPTION
Addresses #22 (that issue will remain open until this fix is backported to the v1 and v2 series)

This PR escapes single quotes in the `html` field (other fields were escaped already). This prevents findings for elements with single quotes (e.g. `<p>Hi y'all!</p>`) from breaking workflows, specifically around [action.yml#86](https://github.com/github/accessibility-scanner/blob/3a0a60f790958e521e9455a6a69d4752fdbeea56/action.yml#L86), where a single-quoted shell string is sent to `jq`.