### PR TITLE
chore: Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,46 +4,49 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/.github/actions/auth"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/.github/actions/find"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/.github/actions/file"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/.github/actions/fix"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/auth"
+      - "/.github/actions/find"
+      - "/.github/actions/file"
+      - "/.github/actions/fix"
+    groups:
+      # Open PRs for each major version and security update
+      # Open an aggregate PR for all minor and patch version updates
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/gh-cache/cache"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/gh-cache/delete"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/gh-cache/restore"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/gh-cache/save"
+    directories:
+      - "/"
+      - "/.github/actions/gh-cache/cache"
+      - "/.github/actions/gh-cache/delete"
+      - "/.github/actions/gh-cache/restore"
+      - "/.github/actions/gh-cache/save"
+    groups:
+      # Open an aggregate PR for all GitHub Actions updates
+      github-actions:
+        patterns:
+          - "*"
     schedule:
       interval: "weekly"
   - package-ecosystem: "bundler"
     directory: "/sites/site-with-errors"
+    groups:
+      # Open PRs for each major version and security update
+      # Open an aggregate PR for all minor and patch version updates
+      bundler-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR configures Dependabot to batch certain types of updates:
- Dependabot will continue to open a PR per major version bump (since those could require breaking changes, slowing down other updates).
- Dependabot will continue to open a PR per security update (so these can be merged quickly, not slowed down by other updates).
- Dependabot will open a single PR per ecosystem (npm, bundler, github-actions) batching all other updates (e.g. minor and patch).

[Dependabot opened 7 PRs yesterday](https://github.com/github/accessibility-scanner/pulls?q=is%3Apr+author%3Adependabot%5Bbot%5D+created%3A2025-10-27+). With this PR’s configuration, it would have opened just 3—that’s easier to review, and a >50% savings in Actions minutes!