### PR TITLE
feat: Log the actual page being scanned

### DIFF
--- a/.github/actions/find/src/findForUrl.ts
+++ b/.github/actions/find/src/findForUrl.ts
@@ -9,6 +9,7 @@ export async function findForUrl(url: string, authContext?: AuthContext): Promis
   const context = await browser.newContext(contextOptions);
   const page = await context.newPage();
   await page.goto(url);
+  console.log(`Scanning ${page.url()}`);
 
   let findings: Finding[] = [];
   try {

--- a/.github/actions/find/src/index.ts
+++ b/.github/actions/find/src/index.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   let findings = [];
   for (const url of urls) {
-    core.info(`Scanning ${url}`);
+    core.info(`Preparing to scan ${url}`);
     const findingsForUrl = await findForUrl(url, authContext);
     if (findingsForUrl.length === 0) {
       core.info(`No accessibility gaps were found on ${url}`);


### PR DESCRIPTION
Fixes https://github.com/github/continuous-ai-for-accessibility/issues/79 (Hubber access only)

This PR logs the URL _actually_ open in the Playwright-driven browser, revealing whether the scanner is repeatedly scanning a login or 404 page instead of the intended page.