### PR TITLE
feat: Use relative paths to reference sub-actions in composite actions

### DIFF
--- a/.github/actions/gh-cache/cache/action.yml
+++ b/.github/actions/gh-cache/cache/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       run: |
         mkdir -p /home/runner/work/_actions/current/.github/actions
-        cp -Rf ../../../../.github/actions/* /home/runner/work/_actions/current/.github/actions
+        rsync -a ../../../../.github/actions/ /home/runner/work/_actions/current/.github/actions/
         ls -ltra /home/runner/work/_actions/current/.github/actions
     - name: Restore cached value
       uses: ./../../_actions/current/.github/actions/gh-cache/restore

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: |
         mkdir -p /home/runner/work/_actions/current/.github/actions
-        cp -Rf .github/actions/* /home/runner/work/_actions/current/.github/actions
+        rsync -a .github/actions/ /home/runner/work/_actions/current/.github/actions/
         ls -ltra /home/runner/work/_actions/current/.github/actions
     - name: Restore cached results
       id: restore


### PR DESCRIPTION
Fixes https://github.com/github/continuous-ai-for-accessibility/issues/87 (Hubber access only)
Fixes https://github.com/github/continuous-ai-for-accessibility/issues/81 (Hubber access only)

### Problem

`uses: github/accessibility-scanner@main` currently fails with the following error—

> Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/accessibility-sandbox/accessibility-sandbox/.github/actions/gh-cache/cache'. Did you forget to run actions/checkout before running your local action?

—this PR makes it work.

### Solution

This PR basically moves the preparatory `cp` workflow step [we used to require](https://github.com/github/accessibility-scanner/tree/bc0c7650825e578c243347fe551f247826bcb70e?tab=readme-ov-file#1-add-a-workflow-file) into the composite action(s) itself.

This PR is a superior alternative to https://github.com/github/accessibility-scanner/commit/c2624690c044733d13c115e95c451b959fcfa7f0:
1. It restores our ability to merge `main` directly into `v2`, which simplifies backports (e.g. dependency updates that Dependabot opens for `main`).
2. It means referencing a point release (e.g. `uses: github/accessibility-scanner@v2.4.0`) _only_ runs code from that release (rather than a mix of `v2.4.0` and (newer) `v2` code).

### Testing

- I tested using `uses: github/accessibility-scanner@smockle/restore-relative-paths`, and it worked: https://github.com/github/accessibility-sandbox/actions/runs/18943849865 (Hubber access only)
- I tested using a sub-action directly (e.g. `uses: github/accessibility-scanner/.github/actions/gh-cache/cache@smockle/restore-relative-paths`), and it worked: https://github.com/github/accessibility-sandbox/actions/runs/18945624950 (Hubber access only)
- The “Test” CI check passed: https://github.com/github/accessibility-scanner/actions/runs/18944419202/job/54092648187?pr=59