### PR TITLE
fix(Auth): Find username fields labelled 'user name'

### DIFF
--- a/.github/actions/auth/src/index.ts
+++ b/.github/actions/auth/src/index.ts
@@ -47,7 +47,7 @@ export default async function () {
     // If no login form is found, then either HTTP Basic auth succeeded, or the page does not require authentication.
     core.info("Checking for login form");
     const [usernameField, passwordField] = await Promise.all([
-      page.getByLabel(/username/i).first(),
+      page.getByLabel(/user ?name/i).first(),
       page.getByLabel(/password/i).first(),
     ]);
     const [usernameFieldExists, passwordFieldExists] = await Promise.all([


### PR DESCRIPTION
Fixes https://github.com/github/continuous-ai-for-accessibility/issues/80 (Hubber access only)

This PR updates the “Auth” sub-action to find username fields labelled “user name” or “username”.

Before https://github.com/github/accessibility-sandbox/actions/runs/18947551717/job/54103069255 (Hubber access only):
```
Starting 'auth' action
Navigating to login page
Checking for login form
No login form detected
Finished 'auth' action
```

After https://github.com/github/accessibility-sandbox/actions/runs/18947605567/job/54103255182 (Hubber access only):
```
Starting 'auth' action
Navigating to login page
Checking for login form
Filling username
Filling password
Logging in
Finished 'auth' action
```