### PR TITLE
fix: Make action paths compatible with both GitHub-hosted and self-hosted runners

### DIFF
--- a/.github/actions/gh-cache/cache/action.yml
+++ b/.github/actions/gh-cache/cache/action.yml
@@ -31,7 +31,7 @@ runs:
         RUNNER_WORK_DIR="$(realpath "${GITHUB_WORKSPACE}/../..")"
         ACTION_DIR="${RUNNER_WORK_DIR}/_actions/github/accessibility-scanner/current"
         mkdir -p "${ACTION_DIR}/.github/actions"
-        if [ "$(realpath .github/actions)" != "$(realpath "${ACTION_DIR}/.github/actions")" ]; then
+        if [ "$(realpath "../../../../.github/actions")" != "$(realpath "${ACTION_DIR}/.github/actions")" ]; then
           cp -a "../../../../.github/actions/." "${ACTION_DIR}/.github/actions/"
         fi
     - name: Restore cached value

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         RUNNER_WORK_DIR="$(realpath "${GITHUB_WORKSPACE}/../..")"
         ACTION_DIR="${RUNNER_WORK_DIR}/_actions/github/accessibility-scanner/current"
         mkdir -p "${ACTION_DIR}/.github/actions"
-        if [ "$(realpath .github/actions)" != "$(realpath "${ACTION_DIR}/.github/actions")" ]; then
+        if [ "$(realpath ".github/actions")" != "$(realpath "${ACTION_DIR}/.github/actions")" ]; then
           cp -a ".github/actions/." "${ACTION_DIR}/.github/actions/"
         fi
     - name: Restore cached results


### PR DESCRIPTION
Follow-up to https://github.com/github/accessibility-scanner/pull/59 (which explains why copy steps and relative paths are used)

Fixes https://github.com/github/accessibility-scanner/issues/71

Instead of assuming actions can be copied to `/home/runner/work` (a path which does not exist on some self-hosted runners), this PR uses `$GITHUB_WORKSPACE/../..` (i.e. the directory above the workflow’s repo and owner directories, aka `$RUNNER_TEMP/..`). That _is_ `/home/runner/work` on GitHub-hosted runners, but it might be `/actions-runner/_work` or `/home/runner/_work` (etc.) on self-hosted runners.

Additionally, this PR uses `cp` in place of `rsync`, since the latter is not installed on some self-hosted runners. It adds an `rsync`-like guard to avoid (errors due to) copying a file over itself.

I tested this branch’s:
- Top-level scanner action on a self-hosted runner: https://github.com/github/accessibility-sandbox/actions/runs/19862994002 (Hubber access only) (this run failed, but for reasons unrelated to paths)
- Top-level scanner action on a GitHub-hosted runner: https://github.com/github/accessibility-sandbox/actions/runs/19863037045 (Hubber access only)
- Nested `gh-cache/*` actions on a self-hosted runner: https://github.com/github/accessibility-sandbox/actions/runs/19863906871 (Hubber access only)
- Nested `gh-cache/*` actions on a GitHub-hosted runner: https://github.com/github/accessibility-sandbox/actions/runs/19863535680 (Hubber access only)