### PR TITLE
fix: Avoid "Argument list too long" when setting `results` output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,8 +109,8 @@ runs:
       uses: actions/github-script@v8
       with:
         script: |
-          const filings = ${{ steps.file.outputs.filings || '' }} || [];
-          const fixings = ${{ steps.fix.outputs.fixings || '' }} || [];
+          const filings = ${{ steps.file.outputs.filings || '""' }} || [];
+          const fixings = ${{ steps.fix.outputs.fixings || '""' }} || [];
           const fixingsByIssueUrl = fixings.reduce((acc, fixing) => {
             if (fixing.issue && fixing.issue.url) {
               acc[fixing.issue.url] = fixing;


### PR DESCRIPTION
This PR updates the “Set results output” step so data from previous steps is directly interpolated into the JS script, rather than passed via environment variables. This prevents “Argument list too long” errors (and resulting workflow failures).

Under the hood, `actions/github-script` was doing something like this:

```shell
FILINGS='/** A huge JSON blob **/' FIXINGS='/** A huge JSON blob **/' node tmp/script.js
```

Depending on the size of `FILINGS` and `FIXINGS`, this could exceed a system’s `ARG_MAX` (https://www.in-ulm.de/~mascheck/various/argmax/ is a good explainer).

After removing the environment variables, the argument list length is much shorter, so the error is avoided.