### PR TITLE
fix(gh-cache/save): Make destination directory(s) before copying files there

### DIFF
--- a/.github/actions/gh-cache/save/action.yml
+++ b/.github/actions/gh-cache/save/action.yml
@@ -64,6 +64,7 @@ runs:
       shell: bash
       run: |
         if [ -f "${{ inputs.path }}" ]; then
+          mkdir -p ".gh-cache-${{ github.run_id }}/$(dirname "${{ inputs.path }}")"
           cp -Rf "${{ inputs.path }}" ".gh-cache-${{ github.run_id }}/${{ inputs.path }}"
           echo "Copied '${{ inputs.path }}' to 'gh-cache' branch"
         fi


### PR DESCRIPTION
When `key` includes `/`, `gh-cache/save` failed with the following error:
> cp: cannot create regular file 'foo/bar.json': No such file or directory

This PR fixes the error by creating the destination directory(s) before performing the copy.

I validated this fix:
- https://github.com/github/accessibility-sandbox/actions/runs/20113417672 (Hubber access only) is a workflow run where the directory did not exist (and so was created)
- https://github.com/github/accessibility-sandbox/actions/runs/20113449371 (Hubber access only) is a follow-up workflow run after the directory did exist (and was reused without error)