### PR TITLE
Change page.goto to wait for DOM content to load

### DIFF
--- a/.github/actions/find/action.yml
+++ b/.github/actions/find/action.yml
@@ -13,6 +13,8 @@ inputs:
 outputs:
   findings:
     description: "List of potential accessibility gaps, as stringified JSON"
+  page_content:
+    description: "Content of the scanned page"
 
 runs:
   using: "node24"

--- a/.github/actions/find/src/findForUrl.ts
+++ b/.github/actions/find/src/findForUrl.ts
@@ -3,12 +3,12 @@ import AxeBuilder from '@axe-core/playwright'
 import playwright from 'playwright';
 import { AuthContext } from './AuthContext.js';
 
-export async function findForUrl(url: string, authContext?: AuthContext): Promise<Finding[]> {
+export async function findForUrl(url: string, authContext?: AuthContext) {
   const browser = await playwright.chromium.launch({ headless: true, executablePath: process.env.CI ? '/usr/bin/google-chrome' : undefined });
   const contextOptions = authContext?.toPlaywrightBrowserContextOptions() ?? {};
   const context = await browser.newContext(contextOptions);
   const page = await context.newPage();
-  await page.goto(url, { 
+  await page.goto(url, {
     waitUntil: 'load',
     // - looks like default timeout is 3000ms
     // - increasing for testing
@@ -18,7 +18,7 @@ export async function findForUrl(url: string, authContext?: AuthContext): Promis
   console.log('*** page content');
   const content = await page.content();
   console.log(content);
-  
+
   console.log(`Scanning ${page.url()}`);
 
   let findings: Finding[] = [];
@@ -41,5 +41,5 @@ export async function findForUrl(url: string, authContext?: AuthContext): Promis
   }
   await context.close();
   await browser.close();
-  return findings;
+  return { findings, content};
 }

--- a/.github/actions/find/src/index.ts
+++ b/.github/actions/find/src/index.ts
@@ -15,7 +15,8 @@ export default async function () {
   let findings = [];
   for (const url of urls) {
     core.info(`Preparing to scan ${url}`);
-    const findingsForUrl = await findForUrl(url, authContext);
+    const { findings: findingsForUrl, content } = await findForUrl(url, authContext);
+    core.setOutput("page_content", content);
     if (findingsForUrl.length === 0) {
       core.info(`No accessibility gaps were found on ${url}`);
       continue;


### PR DESCRIPTION
Fix an [issue](https://github.com/github/accessibility-scanner/issues/96) where axe violations are found while the page is still potentially loading (so the flagged violation is potentially incorrect)