### PR TITLE
Address v3.4.1 release review feedback

### DIFF
--- a/.github/actions/find/README.md
+++ b/.github/actions/find/README.md
@@ -38,8 +38,9 @@ configuration option.
 #### `scans`
 
 **Optional** Stringified JSON array of scans to perform. Core engines and local plugins use string names.
-Allowlisted NPM plugins use an object with `name`, `package`, and optional `version`. If not provided, only Axe
-will be performed. See [the plugin docs](../../../PLUGINS.md#loading-plugins-from-npm-packages) for an example.
+Allowlisted NPM plugins use an object with `name`, `package`, and optional `version`, and require scanner v3.4.1
+or later. If not provided, only Axe will be performed. See
+[the plugin docs](../../../PLUGINS.md#loading-plugins-from-npm-packages) for an example.
 
 ### Outputs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.4'
           bundler-cache: true

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,5 +1,9 @@
 # Plugins
 
+## Minimum scanner version
+
+Loading plugins from NPM packages requires scanner v3.4.1 or later.
+
 The plugin system allows teams to create custom scans/tests to run on their pages. An example of this is Axe interaction tests. In some cases, it might be desirable to perform specific interactions on elements of a given page before doing an Axe scan. These interactions are usually unique to each page that is scanned, so it would require the owning team to write a custom plugin that can interact with the page and run the Axe scan when ready. See the existing plugins under [.github/scanner-plugins](https://github.com/github/accessibility-scanner/tree/main/.github/scanner-plugins) for examples of plugin structure.
 
 Some plugins come built-in with the scanner and can be enabled via [actions inputs](https://github.com/github/accessibility-scanner/tree/main/action.yml#L48-L50).
@@ -46,7 +50,6 @@ jobs:
 ## Loading plugins from NPM packages
 
 In addition to local plugins under `./.github/scanner-plugins`, the scanner can install and load plugins published as NPM packages. This avoids having to vendor a plugin's source into your repo.
-NPM package loading requires scanner v3.4.1 or later.
 
 To use an NPM plugin, pass an object (instead of a plain string) in the `scans` input with the following fields:
 


### PR DESCRIPTION
## Summary

Addresses the documentation and action-pin feedback from the v3.4.1 release PR (#253):

- calls out scanner v3.4.1 as the minimum version for NPM plugin loading
- moves the minimum version requirement to the top of the plugin documentation
- annotates the pinned `ruby/setup-ruby` SHA with its release version